### PR TITLE
[Misc]Fix incorrect local IP detection in multi-network interface environments

### DIFF
--- a/examples/online_serving/run_cluster.sh
+++ b/examples/online_serving/run_cluster.sh
@@ -32,7 +32,7 @@ trap cleanup EXIT
 # Command setup for head or worker node
 RAY_START_CMD="ray start --block"
 if [ "${NODE_TYPE}" == "--head" ]; then
-    RAY_START_CMD+=" --head --port=6379"
+    RAY_START_CMD+=" --head --node-ip-address=${HEAD_NODE_ADDRESS} --port=6379"
 else
     RAY_START_CMD+=" --address=${HEAD_NODE_ADDRESS}:6379"
 fi


### PR DESCRIPTION
- Updated `run_cluster.sh` to explicitly set `--node-ip-address` for Ray head node startup
- Ensures Ray head node uses the IP defined by `VLLM_HOST_IP` environment variable
- Resolves conflicts when nodes have multiple network interfaces (e.g., eth0, eth1)

#### **Problem**  
When deploying vLLM in multi-node environments with nodes that have multiple network interfaces, the Ray head node might detect an incorrect local IP address (e.g., choosing `eth1` instead of the intended `eth0`). This causes inconsistencies with the `VLLM_HOST_IP` environment variable and breaks cross-node communication.

#### **Solution**  
- Explicitly pass `--node-ip-address=$VLLM_HOST_IP` to the Ray head node startup command in `run_cluster.sh`.  
- Forces Ray to bind to the IP specified by `VLLM_HOST_IP`, overriding its automatic interface detection logic.  

#### **Testing Done**  
- Validated in a cluster with dual NICs (eth0: `10.0.1.12`, eth1: `192.168.1.12`):  
  - Set `VLLM_HOST_IP=10.0.1.12`  
  - Verified Ray head node logs: `Local node IP: 10.0.1.12`  
  - Confirmed worker nodes connected to the head node via `10.0.1.12`  

#### **Notes**  
- Requires `VLLM_HOST_IP` to be set correctly on all nodes.  
- Aligns with Ray’s best practices for IP assignment in complex networks ([Ray Docs](https://docs.ray.io/en/latest/cluster/faq.html#what-s-the-difference-between-node-ip-address-and-address)).  

FIX #7815
